### PR TITLE
warn for out-of-spec content-type header

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -325,7 +325,7 @@
                         var contentType = res.response.headers['content-type'];
                         if (contentType.indexOf('xml') === -1 &&
                             contentType.indexOf('wsdl') === -1) {
-                            throw new Error('no wsdl/xml response');
+                            console.warn('response content-type neither wsdl nor xml');
                         }
 
                         saveWsdlToCache(params, res.body);


### PR DESCRIPTION
continue on with best-effort instead of throwing exception on unexpected content-type value

fix for #3 